### PR TITLE
PST-2763: Add Teamcity messages to xcpretty error formatting

### DIFF
--- a/lib/teamcity_formatter.rb
+++ b/lib/teamcity_formatter.rb
@@ -12,6 +12,7 @@ class TeamCityFormatter < XCPretty::Simple
 
   def initialize(use_unicode, colorize)
     super
+    STDOUT.puts "##teamcity[compilationStarted compiler='xcodebuild']"
     @warnings = []
     @ld_warnings = []
     @compile_warnings = []
@@ -22,6 +23,9 @@ class TeamCityFormatter < XCPretty::Simple
     @duplicate_symbols_errors = []
     @failures = {}
     @tests_summary_messages = []
+    at_exit do
+      STDOUT.puts "##teamcity[compilationFinished compiler='xcodebuild']"
+    end
   end
 
   # These first 6 overrides don't log to the json file.
@@ -94,6 +98,7 @@ class TeamCityFormatter < XCPretty::Simple
       cursor: cursor
     }
     write_to_file_if_needed
+    teamcity_error_message("CompileError", "#{file_path}: #{reason}\n#{line}\n#{cursor}")
     super
   end
 
@@ -103,6 +108,7 @@ class TeamCityFormatter < XCPretty::Simple
       reason: reason
     }
     write_to_file_if_needed
+    teamcity_error_message("FileMissingError", "#{file_path}: #{reason}")
     super
   end
 
@@ -113,6 +119,10 @@ class TeamCityFormatter < XCPretty::Simple
       reference: reference
     }
     write_to_file_if_needed
+    teamcity_error_message("UndefinedSymbolsError",
+      "#{message}\n" \
+      "> Symbol: #{symbol}\n" \
+      "> Referenced from: #{reference}")
     super
   end
 
@@ -122,6 +132,9 @@ class TeamCityFormatter < XCPretty::Simple
       file_paths: file_paths
     }
     write_to_file_if_needed
+    teamcity_error_message("DuplicateSymbolsError",
+      "#{message}\n" \
+      "> #{file_paths.join("\n> ")}")
     super
   end
 
@@ -130,6 +143,18 @@ class TeamCityFormatter < XCPretty::Simple
     @tests_summary_messages << message
     write_to_file_if_needed
     super
+  end
+
+  def teamcity_error_message(message, details)
+    STDOUT.puts "##teamcity[message text='#{message}' errorDetails='#{format_details(details)}' status='ERROR']\n"
+  end
+
+  def format_details(detail)
+    detail.gsub('|', '||')
+          .gsub("\n", '|n')
+          .gsub("'", "|'")
+          .gsub('[', '|[')
+          .gsub(']', '|]')
   end
 
   def finish

--- a/lib/teamcity_formatter.rb
+++ b/lib/teamcity_formatter.rb
@@ -149,6 +149,8 @@ class TeamCityFormatter < XCPretty::Simple
     STDOUT.puts "##teamcity[message text='#{message}' errorDetails='#{format_details(details)}' status='ERROR']\n"
   end
 
+  # Need to sub out characters so that TC can parse the ##teamcity message correctly
+  # https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-Escapedvalues
   def format_details(detail)
     detail.gsub('|', '||')
           .gsub("\n", '|n')


### PR DESCRIPTION
To get better build summaries on failed builds, we need to give TeamCity some extra messages so that it can actually put the xcodebuild error on the build summary page. By grouping the Gym output for xcodebuild into a `CompiledStarted` and `CompiledFinished` block, this allows us to set error messages for TC to pick up when there is a compile error. Since the message happen inside the compile block, the build summary has the file path, line and reason of the error! 🥇 

Formatting for the `errorDetails` came from xcpretty: https://github.com/xcpretty/xcpretty/blob/456604313faf4a1de6a4e687c2412eaf6097c4b0/lib/xcpretty/formatters/formatter.rb

JIRA Ticket: https://hudl-jira.atlassian.net/browse/PST-2763

Examples:
Build/Distribute(Fabric) compile error
<img width="1241" alt="Screen Shot 2019-11-21 at 3 14 52 PM" src="https://user-images.githubusercontent.com/8480230/69377351-b1ad8c00-0c71-11ea-9bec-4fa180beb76a.png">

Compile App for Tests compile error
<img width="1276" alt="Screen Shot 2019-11-21 at 2 49 58 PM" src="https://user-images.githubusercontent.com/8480230/69375565-40200e80-0c6e-11ea-82ad-0f2ae20005ba.png">

Failed Unit Test
<img width="1282" alt="Screen Shot 2019-11-21 at 3 11 57 PM" src="https://user-images.githubusercontent.com/8480230/69377251-83c84780-0c71-11ea-89da-7b5e8047ed91.png">

